### PR TITLE
[BUGFIX] Generate cli_dispatch.phpsh for TYPO3v8

### DIFF
--- a/src/Composer/InstallerScript/LegacyCliEntryPoint.php
+++ b/src/Composer/InstallerScript/LegacyCliEntryPoint.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+namespace Helhum\Typo3ComposerSetup\Composer\InstallerScript;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Composer\Script\Event;
+use Composer\Util\Filesystem;
+use TYPO3\CMS\Composer\Plugin\Core\InstallerScript;
+
+class LegacyCliEntryPoint implements InstallerScript
+{
+    /**
+     * The target file relative to the web directory
+     *
+     * @var string
+     */
+    private $target;
+
+    public function __construct(string $target)
+    {
+        $this->target = $target;
+    }
+
+    public function run(Event $event): bool
+    {
+        $filesystem = new Filesystem();
+
+        $entryPointContent = <<<CONTENT
+#!/usr/bin/env php
+<?php
+// This entry-point is deprecated since TYPO3 v8 and will be removed in TYPO3 v9
+// Use the binary located typo3/sysext/core/bin/typo3 instead.
+require __DIR__ . '/cli.php';
+CONTENT;
+
+        $filesystem->ensureDirectoryExists(dirname($this->target));
+        file_put_contents($this->target, $entryPointContent);
+        chmod($this->target, 0755);
+
+        return true;
+    }
+}

--- a/src/Composer/InstallerScripts.php
+++ b/src/Composer/InstallerScripts.php
@@ -18,6 +18,7 @@ namespace Helhum\Typo3ComposerSetup\Composer;
 use Composer\Script\Event;
 use Composer\Semver\Constraint\EmptyConstraint;
 use Helhum\Typo3ComposerSetup\Composer\InstallerScript\EntryPoint;
+use Helhum\Typo3ComposerSetup\Composer\InstallerScript\LegacyCliEntryPoint;
 use Helhum\Typo3ComposerSetup\Composer\InstallerScript\RootDirectory;
 use TYPO3\CMS\Composer\Plugin\Config;
 use TYPO3\CMS\Composer\Plugin\Core\InstallerScriptsRegistration;
@@ -44,13 +45,18 @@ class InstallerScripts implements InstallerScriptsRegistration
         );
 
         foreach ($entryPointFinder->find($webDir) as $entryPoint) {
-            $scriptDispatcher->addInstallerScript(
-                new EntryPoint(
+            if ($entryPoint['legacy_cli'] ?? false) {
+                $entryPoint = new LegacyCliEntryPoint(
+                    $entryPoint['target']
+                );
+            } else {
+                $entryPoint = new EntryPoint(
                     $entryPoint['source'],
                     $entryPoint['target']
-                ),
-                80
-            );
+                );
+            }
+
+            $scriptDispatcher->addInstallerScript($entryPoint, 80);
         }
 
         $rootDir = $pluginConfig->get('root-dir');

--- a/src/Composer/Typo3EntryPointFinder.php
+++ b/src/Composer/Typo3EntryPointFinder.php
@@ -90,6 +90,18 @@ class Typo3EntryPointFinder
             throw new \UnexpectedValueException('Could not determine backend entry point. typo3/cms is not installed?', 1502706254);
         }
 
+        if (file_exists($backendCliSourceFile = $backendPackagePath . '/Resources/Private/Php/cli.php') ||
+            file_exists($backendCliSourceFile = $cmsInstallPath . '/typo3/sysext/backend/Resources/Private/Php/cli.php')) {
+            $entryPoints['backend_cli'] = [
+                'source' => $backendCliSourceFile,
+                'target' => $targetPath . '/typo3/cli.php',
+            ];
+            $entryPoints['backend_cli_dispatch'] = [
+                'target' => $targetPath . '/typo3/cli_dispatch.phpsh',
+                'legacy_cli' => true,
+            ];
+        }
+
         if (file_exists($installSourceFile = $installPackagePath . '/Resources/Private/Php/install.php')) {
             $entryPoints['install']['source'] = $installSourceFile;
         } elseif (isset($cmsInstallPath)) {


### PR DESCRIPTION
Although deprecated we should still provide this entrypoint for TYPO3v8
to make the migration as smooth as possible.